### PR TITLE
Add Waitlio to Launch Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 * [Carrd](https://carrd.co) – Quickly spin up a landing page for your launch.
 * [Substack](https://substack.com) – Build an audience and launch with a newsletter.
 * [Startup Tools List](https://startuptoolslist.com) – Discover tools to help launch and grow.
+* [Waitlio](https://waitlio.com) – Free waitlist software for product launches with branded pages, email verification, and API.
 
 ---
 


### PR DESCRIPTION
## Add Waitlio to Launch Tools

Adds [Waitlio](https://waitlio.com) to the 🧰 Launch Tools section.

Waitlio is free waitlist software for product launches — lets you build branded waitlist pages, collect and verify email signups, manage subscribers, with webhooks, REST API, and team collaboration. Freemium pricing.