### PR TITLE
Add ZPlatform.ai to AI & Tool-Focused Launch Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 * [Futurepedia](https://futurepedia.wiki) – AI tools aggregator with launch listings.
 * [Productivity Directory](https://productivity.directory) – Find Productivity Tools
 * [Toolkitly](https://www.toolkitly.com) – Your Go-To Platform for Tech Tool Discussions, Innovations & Real-Time Updates!
+* [ZPlatform.ai](https://zplatform.ai/) – Directory of AI tools and SaaS deals, each tested hands-on with a Buy/Wait/Skip verdict and organized by category.
 
 
 ---


### PR DESCRIPTION
Adds [ZPlatform.ai](https://zplatform.ai/) to the **AI & Tool-Focused Launch Directories** section.

ZPlatform.ai is a directory of AI tools and SaaS deals where each tool is tested hands-on and given a Buy/Wait/Skip verdict, organized by category. AI tools and SaaS can also be listed on the platform for visibility, which fits the scope of this list.

Entry follows the existing section format and tone.