### PR TITLE
Add CazaProducto to Niche/Regional Launch Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 ## 🗂 Niche or Regional Launch Platforms
 
 * [Startuplist Africa](https://startuplist.africa) – Discover and launch African startups.
+* [CazaProducto](https://cazaproducto.com) – Latin America's own Product Hunt, where regional makers launch and get discovered.
 * [Side Projectors](https://www.sideprojectors.com) – Promote and even sell your side project.
 * [Remote Tools](https://www.remote.tools) – Focused on tools for remote workers and teams.
 * [ToolFinder](https://toolfinder.wiki) - Discover & browse thousands of productivity tools. 


### PR DESCRIPTION
CazaProducto (https://cazaproducto.com) is a regional launch platform for Latin America, similar in spirit to Product Hunt but focused on the LatAm maker community. Adding it alongside Startuplist Africa under regional platforms.