### PR TITLE
Add JustLaunched to General Launch Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * [Launching Next](https://www.launchingnext.com) – List your project for free exposure.
 * [Open Launch](https://open-launch.com/) - Opensource alternative to ProductHunt
 * [PeerPush](https://peerpush.net/) - Get instant visibility for your product. Be discovered by people who care now.
+* [JustLaunched](https://justlaunched.fyi) – Submit and discover newly launched SaaS products, organized by category, to reach early adopters.
 
 ---
 


### PR DESCRIPTION
Hi! I'm the founder of [JustLaunched](https://justlaunched.fyi), a directory where founders submit and discover newly launched SaaS products, organized by category to reach early adopters.

Added one entry to **General Launch Platforms**, matching the existing `* [Name](url) – description` format. Happy to move it to a different section if you'd prefer. Thanks!