### PR TITLE
Add SaaSCity to General Launch Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * [Launching Next](https://www.launchingnext.com) – List your project for free exposure.
 * [Open Launch](https://open-launch.com/) - Opensource alternative to ProductHunt
 * [PeerPush](https://peerpush.net/) - Get instant visibility for your product. Be discovered by people who care now.
+* [SaaSCity](https://saascity.io) – Gamified SaaS directory where every listing becomes a building on a live isometric city map.
 
 ---
 


### PR DESCRIPTION
Adds **SaaSCity** to the list.

- **URL:** https://saascity.io
- **Submit page:** https://saascity.io/submit
- **Domain Rating:** 46 (Ahrefs)
- **Listing:** free listing with an indexed product page; paid tiers add a dofollow backlink and map placement
- **Review:** every submission is manually reviewed, usually approved within 24h

SaaSCity is a gamified SaaS directory — each listing becomes a building on a live isometric city map.

The entry follows the existing format used in this section.