### PR TITLE
Add Toolfound to General Launch Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * [Launching Next](https://www.launchingnext.com) – List your project for free exposure.
 * [Open Launch](https://open-launch.com/) - Opensource alternative to ProductHunt
 * [PeerPush](https://peerpush.net/) - Get instant visibility for your product. Be discovered by people who care now.
+* [Toolfound](https://toolfound.com) – Launch platform and tool directory with a transparent queue, mandatory ownership verification, and an agent-native MCP submission path.
 
 ---
 


### PR DESCRIPTION
Adds [Toolfound](https://toolfound.com) — a launch platform + tool directory (142 listings, 31 categories).

Why it fits this list:
- Free to launch for the first 100 products (live public counter on the homepage)
- Transparent queue: position and launch date visible before submitting
- Dofollow listing links by default; badges optional, never required
- Mandatory ownership verification keeps listings legitimate
- Full launch lifecycle also available over MCP (12 tools) for agent-driven workflows: https://toolfound.com/api/mcp

Entry follows the existing format. Happy to adjust wording or placement.

(Disclosure: submitting my own project.)