### PR TITLE
Add Launch Llama to General Launch Platforms (Update README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * [Launching Next](https://www.launchingnext.com) – List your project for free exposure.
 * [Open Launch](https://open-launch.com/) - Opensource alternative to ProductHunt
 * [PeerPush](https://peerpush.net/) - Get instant visibility for your product. Be discovered by people who care now.
+* [Launch Llama Directory](https://tools.launchllama.co) - Submit your product and get discovered in our 55k newsletter. 
 
 ---
 


### PR DESCRIPTION
Adds Launch Llama (tools.launchllama.co) to the General Launch Platforms  section — a directory for discovering and launching on tools and  directories to grow a startup.